### PR TITLE
fix/align-affiliation-text-to-center

### DIFF
--- a/frontend/src/components/PeopleCard.jsx
+++ b/frontend/src/components/PeopleCard.jsx
@@ -40,7 +40,7 @@ function PeopleCard({ person }) {
                 <p className="text-center">{person["Given Name"]} </p>
                 <p>{person["Family Name"]} </p>
               </div>
-              {person["Affiliation"] && person["Role"] == "Collaborator" ? (<p className="bodySmall">{person["Affiliation"]}</p>) : (<p className="bodySmall">{person["Role"]}</p>) }
+              {person["Affiliation"] && person["Role"] == "Collaborator" ? (<p className="bodySmall text-center">{person["Affiliation"]}</p>) : (<p className="bodySmall">{person["Role"]}</p>) }
             </div>
           </div>
         </>


### PR DESCRIPTION
added 'text-center' for vertical alignment for affiliation text. this is a quick fix for people page.